### PR TITLE
BVS-2675 support t6 test path in horizon gui

### DIFF
--- a/openstack_dashboard/dashboards/project/connections/reachability_tests/bcf_testpath_api.py
+++ b/openstack_dashboard/dashboards/project/connections/reachability_tests/bcf_testpath_api.py
@@ -9,9 +9,9 @@ from openstack_dashboard.dashboards.project.connections import bsn_api
 eventlet.monkey_patch()
 URL_TEST_PATH = ('applications/bcf/test/path/controller-view'
                  '[src-tenant=\"%(src-tenant)s\"]'
-                 '[src-segment=\"%(src-segment)s\"][src-ip=\"%(src-ip)s\"]'
-                 '[dst-tenant=\"%(dst-tenant)s\"]'
-                 '[dst-segment=\"%(dst-segment)s\"][dst-ip=\"%(dst-ip)s\"]')
+                 '[src-segment=\"%(src-segment)s\"]'
+                 '[src-ip=\"%(src-ip)s\"]'
+                 '[dst-ip=\"%(dst-ip)s\"]')
 
 
 class ControllerCluster(object):
@@ -100,8 +100,7 @@ class ControllerCluster(object):
                {'src-tenant': src['tenant'],
                 'src-segment': src['segment'],
                 'src-ip': src['ip'],
-                'dst-tenant': dst['tenant'],
-                'dst-segment': dst['segment'], 'dst-ip': dst['ip']})
+                'dst-ip': dst['ip']})
         controller = self.active_controller
         ret = rest_lib.get(self.cookie, url,
                            controller, self.port)

--- a/openstack_dashboard/dashboards/project/connections/reachability_tests/forms.py
+++ b/openstack_dashboard/dashboards/project/connections/reachability_tests/forms.py
@@ -43,7 +43,6 @@ import openstack_dashboard.dashboards.project.connections.bsn_api as bsn_api
 
 NEW_LINES = re.compile(r"\r|\n")
 EXPECTATION_CHOICES = [('default', _('--- Select Result ---')),
-                       ('reached destination', _('reached destination')),
                        ('dropped by route', _('dropped by route')),
                        ('dropped by policy', _('dropped by policy')),
                        ('dropped due to private segment',
@@ -51,9 +50,11 @@ EXPECTATION_CHOICES = [('default', _('--- Select Result ---')),
                        ('packet in', _('packet in')),
                        ('forwarded', _('forwarded')),
                        ('dropped', _('dropped')),
-                       ('multiple sources', _('multiple sources')),
+                       ('unspecified sources', _('unspecified sources')),
                        ('unsupported', _('unsupported')),
-                       ('invalid input', _('invalid input'))]
+                       ('invalid input', _('invalid input')),
+                       ('inconsistent status', _('inconsistent status')),
+                       ('no traffic detected', _('no traffic detected'))]
 
 
 class CreateReachabilityTest(forms.SelfHandlingForm):
@@ -65,7 +66,6 @@ class CreateReachabilityTest(forms.SelfHandlingForm):
     def __init__(self, request, *args, **kwargs):
         super(CreateReachabilityTest, self).__init__(request, *args, **kwargs)
         self.fields['tenant_source'].initial = request.user.project_id
-        self.fields['tenant_destination'].initial = request.user.project_id
 
     tenant_source = forms.CharField(
         max_length="255",
@@ -96,26 +96,6 @@ class CreateReachabilityTest(forms.SelfHandlingForm):
             attrs={'class': 'switched',
                    'data-connection_source_type-ip':
                    _('Specify source IP address')}))
-
-    tenant_destination = forms.CharField(
-        max_length="255",
-        label=_("Sepecify destination tenant"),
-        required=True,
-        initial="",
-        widget=forms.TextInput(
-            attrs={'class': 'switched',
-                   'data-connection_destination-tenant':
-                   _('Specify destination tenant')}))
-
-    segment_destination = forms.CharField(
-        max_length="255",
-        label=_("Sepecify destination segment"),
-        required=True,
-        initial="",
-        widget=forms.TextInput(
-            attrs={'class': 'switched',
-                   'data-connection_destination-segment':
-                   _('Specify destination segment')}))
 
     ip_destination = forms.CharField(
         max_length="255",
@@ -157,8 +137,6 @@ class CreateReachabilityTest(forms.SelfHandlingForm):
             'src_tenant_id': data['tenant_source'].encode('ascii'),
             'src_segment_id': data['segment_source'].encode('ascii'),
             'src_ip': data['ip_source'].encode('ascii', 'ignore'),
-            'dst_tenant_id': data['tenant_destination'].encode('ascii'),
-            'dst_segment_id': data['segment_destination'].encode('ascii'),
             'dst_ip': data['ip_destination'].encode('ascii', 'ignore'),
             'expected_result': data['expected_connection'].encode('ascii',
                                                                   'ignore')
@@ -178,7 +156,6 @@ class RunQuickTestForm(forms.SelfHandlingForm):
     def __init__(self, request, *args, **kwargs):
         super(RunQuickTestForm, self).__init__(request, *args, **kwargs)
         self.fields['tenant_source'].initial = request.user.project_id
-        self.fields['tenant_destination'].initial = request.user.project_id
 
     tenant_source = forms.CharField(
         max_length="255",
@@ -209,26 +186,6 @@ class RunQuickTestForm(forms.SelfHandlingForm):
             attrs={'class': 'switched',
                    'data-connection_source_type-ip':
                    _('Specify source IP address')}))
-
-    tenant_destination = forms.CharField(
-        max_length="255",
-        label=_("Sepecify destination tenant"),
-        required=True,
-        initial="",
-        widget=forms.TextInput(
-            attrs={'class': 'switched',
-                   'data-connection_destination-tenant':
-                   _('Specify destination tenant')}))
-
-    segment_destination = forms.CharField(
-        max_length="255",
-        label=_("Sepecify destination segment"),
-        required=True,
-        initial="",
-        widget=forms.TextInput(
-            attrs={'class': 'switched',
-                   'data-connection_destination-segment':
-                   _('Specify destination segment')}))
 
     ip_destination = forms.CharField(
         max_length="255",
@@ -269,8 +226,6 @@ class RunQuickTestForm(forms.SelfHandlingForm):
             'src_tenant_id': data['tenant_source'].encode('ascii'),
             'src_segment_id': data['segment_source'].encode('ascii'),
             'src_ip': data['ip_source'].encode('ascii', 'ignore'),
-            'dst_tenant_id': data['tenant_destination'].encode('ascii'),
-            'dst_segment_id': data['segment_destination'].encode('ascii'),
             'dst_ip': data['ip_destination'].encode('ascii', 'ignore'),
             'expected_result': data['expected_connection'].encode('ascii',
                                                                   'ignore')
@@ -295,7 +250,6 @@ class UpdateForm(forms.SelfHandlingForm):
     def __init__(self, request, *args, **kwargs):
         super(UpdateForm, self).__init__(request, *args, **kwargs)
         self.fields['tenant_source'].initial = request.user.project_id
-        self.fields['tenant_destination'].initial = request.user.project_id
 
     tenant_source = forms.CharField(
         max_length="255",
@@ -326,26 +280,6 @@ class UpdateForm(forms.SelfHandlingForm):
             attrs={'class': 'switched',
                    'data-connection_source_type-ip':
                    _('Specify source IP address')}))
-
-    tenant_destination = forms.CharField(
-        max_length="255",
-        label=_("Sepecify destination tenant"),
-        required=True,
-        initial="",
-        widget=forms.TextInput(
-            attrs={'class': 'switched',
-                   'data-connection_destination-tenant':
-                   _('Specify destination tenant')}))
-
-    segment_destination = forms.CharField(
-        max_length="255",
-        label=_("Sepecify destination segment"),
-        required=True,
-        initial="",
-        widget=forms.TextInput(
-            attrs={'class': 'switched',
-                   'data-connection_destination-segment':
-                   _('Specify destination segment')}))
 
     ip_destination = forms.CharField(
         max_length="255",
@@ -386,8 +320,6 @@ class UpdateForm(forms.SelfHandlingForm):
             'src_tenant_id': data['tenant_source'].encode('ascii'),
             'src_segment_id': data['segment_source'].encode('ascii'),
             'src_ip': data['ip_source'].encode('ascii', 'ignore'),
-            'dst_tenant_id': data['tenant_destination'].encode('ascii'),
-            'dst_segment_id': data['segment_destination'].encode('ascii'),
             'dst_ip': data['ip_destination'].encode('ascii', 'ignore'),
             'expected_result': data['expected_connection'].encode('ascii',
                                                                   'ignore')

--- a/openstack_dashboard/dashboards/project/connections/reachability_tests/reachability_test_api.py
+++ b/openstack_dashboard/dashboards/project/connections/reachability_tests/reachability_test_api.py
@@ -56,8 +56,6 @@ class ReachabilityTestAPI(object):
                                    src_tenant_id = quick_test.src_tenant_id,
                                    src_segment_id = quick_test.src_segment_id,
                                    src_ip = quick_test.src_ip,
-                                   dst_tenant_id = quick_test.dst_tenant_id,
-                                   dst_segment_id = quick_test.dst_segment_id,
                                    dst_ip = quick_test.dst_ip,
                                    expected_result = quick_test.expected_result)
         self.saveTest(tenant_id, test_id, test, session)
@@ -122,8 +120,6 @@ class ReachabilityTestAPI(object):
         src['segment'] = self.resolve_segment(test.src_segment_id, request)
         src['ip'] = test.src_ip
         dst = {}
-        dst['tenant'] = test.dst_tenant_id
-        dst['segment'] = self.resolve_segment(test.dst_segment_id, request)
         dst['ip'] = test.dst_ip
         bcf = ControllerCluster()
         data = bcf.getTestPath(src, dst)

--- a/openstack_dashboard/dashboards/project/connections/reachability_tests/reachability_test_db.py
+++ b/openstack_dashboard/dashboards/project/connections/reachability_tests/reachability_test_db.py
@@ -36,15 +36,14 @@ class ReachabilityTest(model_base.BASEV2):
     src_tenant_id = sa.Column(sa.String(64), nullable=False)
     src_segment_id = sa.Column(sa.String(64), nullable=False)
     src_ip = sa.Column(sa.String(16), nullable=False)
-    dst_tenant_id = sa.Column(sa.String(64), nullable=False)
-    dst_segment_id = sa.Column(sa.String(64), nullable=False)
     dst_ip = sa.Column(sa.String(16), nullable=False)
-    expected_result = sa.Column(Enum("reached destination", "dropped by route",
+    expected_result = sa.Column(Enum("dropped by route",
                                      "dropped by policy",
                                      "dropped due to private segment",
                                      "packet in", "forwarded", "dropped",
-                                     "multiple sources",
+                                     "unspecified sources",
                                      "unsupported", "invalid input",
+                                     "no traffic detected",
                                      name="expected_result"), nullable=False)
 
     def get_connection_source(self):
@@ -56,8 +55,6 @@ class ReachabilityTest(model_base.BASEV2):
 
     def get_connection_destination(self):
         destination = {}
-        destination['tenant'] = self.dst_tenant_id
-        destination['segment'] = self.dst_segment_id
         destination['ip'] = self.dst_ip
         return destination
 
@@ -91,15 +88,15 @@ class ReachabilityQuickTest(model_base.BASEV2):
     src_tenant_id = sa.Column(sa.String(64), nullable=False)
     src_segment_id = sa.Column(sa.String(64), nullable=False)
     src_ip = sa.Column(sa.String(16), nullable=False)
-    dst_tenant_id = sa.Column(sa.String(64), nullable=False)
-    dst_segment_id = sa.Column(sa.String(64), nullable=False)
     dst_ip = sa.Column(sa.String(16), nullable=False)
-    expected_result = sa.Column(Enum("reached destination", "dropped by route",
+    expected_result = sa.Column(Enum("dropped by route",
                                      "dropped by policy",
                                      "dropped due to private segment",
                                      "packet in", "forwarded", "dropped",
-                                     "multiple sources", "unsupported",
-                                     "invalid input", name="expected_result"),
+                                     "unspecified sources",
+                                     "unsupported", "invalid input",
+                                     "no traffic detected",
+                                     name="expected_result"),
                                      nullable=False)
 
     def get_connection_source(self):
@@ -111,8 +108,6 @@ class ReachabilityQuickTest(model_base.BASEV2):
 
     def get_connection_destination(self):
         destination = {}
-        destination['tenent'] = self.dst_tenant_id
-        destination['segment'] = self.dst_segment_id
         destination['ip'] = self.dst_ip
         return destination
 

--- a/openstack_dashboard/dashboards/project/connections/reachability_tests/views.py
+++ b/openstack_dashboard/dashboards/project/connections/reachability_tests/views.py
@@ -131,7 +131,6 @@ class UpdateView(forms.ModalFormView):
         try:
             src = json.loads(reachability_test.connection_source)
             dst = json.loads(reachability_test.connection_destination)
-            body['segment_destination'] = dst['segment']
             body['segment_source'] = src['segment']
             body['ip_destination'] = dst['ip']
             body['ip_source'] = src['ip']


### PR DESCRIPTION
Reviewer: @kjiang 
In t6, we don't allow user to specify destination tenant and segment. This PR cleans up the db schema.
Test result types are also extended.